### PR TITLE
Add cookieParser to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ app.plug(cookiePlugin());
 
 ```
 
-In your connect/express server side :
+In your connect/express server side include cookieParser and add req/res to the context :
 
 ```javascript
+import cookieParser from 'cookie-parser';
+
+server.use(cookieParser());
 
 server.use((req, res, next) => {
 


### PR DESCRIPTION
It's not obvious that this is required for the plugin to work.

https://github.com/expressjs/cookie-parser